### PR TITLE
Avoid stack level too deep when loading rspec bin file

### DIFF
--- a/heartcheck-newrelic.gemspec
+++ b/heartcheck-newrelic.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/locaweb/heartcheck-newrelic'
 
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
-  spec.bindir = 'bin'
-  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.add_dependency 'heartcheck', '~> 1.0'

--- a/heartcheck-newrelic.gemspec
+++ b/heartcheck-newrelic.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary = 'A Heartcheck plugin for New Relic'
   spec.homepage = 'https://github.com/locaweb/heartcheck-newrelic'
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
+  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|bin)/}) }
   spec.require_paths = ['lib']
 
   spec.add_dependency 'heartcheck', '~> 1.0'


### PR DESCRIPTION
There are some issues when loading rspec, causing it to repeatedly
search through BUNDLE_PATH looking for bin/rspec. This conflict leads
to stack level too deep.

There is no need to publish those files at all, since they look related
to dev environment, and shouldn't be present in production ones.

Ex.:

```
$ bundle exec rspec
/usr/local/lib/site_ruby/2.3.0/bundler/settings.rb:97:in `block (5 levels) in []': stack level too deep (SystemStackError)
	from /usr/local/lib/site_ruby/2.3.0/bundler/settings.rb:97:in `fetch'
	from /usr/local/lib/site_ruby/2.3.0/bundler/settings.rb:97:in `block (4 levels) in []'
	from /usr/local/lib/site_ruby/2.3.0/bundler/settings.rb:96:in `fetch'
	from /usr/local/lib/site_ruby/2.3.0/bundler/settings.rb:96:in `block (3 levels) in []'
	from /usr/local/lib/site_ruby/2.3.0/bundler/settings.rb:95:in `fetch'
	from /usr/local/lib/site_ruby/2.3.0/bundler/settings.rb:95:in `block (2 levels) in []'
	from /usr/local/lib/site_ruby/2.3.0/bundler/settings.rb:94:in `fetch'
	from /usr/local/lib/site_ruby/2.3.0/bundler/settings.rb:94:in `block in []'
	 ... 6959 levels...
	from /builds/SMTP/saas-smtp-workers/vendor/bundle/ruby/2.3.0/gems/heartcheck-newrelic-0.1.0/bin/rspec:17:in `load'
	from /builds/SMTP/saas-smtp-workers/vendor/bundle/ruby/2.3.0/gems/heartcheck-newrelic-0.1.0/bin/rspec:17:in `<top (required)>'
	from /builds/SMTP/saas-smtp-workers/vendor/bundle/ruby/2.3.0/bin/rspec:23:in `load'
	from /builds/SMTP/saas-smtp-workers/vendor/bundle/ruby/2.3.0/bin/rspec:23:in `<main>'
```